### PR TITLE
snapcraft.yaml: change arch to arm64

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
  Support files for booting the 96boards dragonboard
 type: gadget
 architectures:
-  - armhf
+  - arm64
 confinement: strict
 grade: stable
 parts:


### PR DESCRIPTION
This PR resolves LP: [#1677079](https://bugs.launchpad.net/snap-dragonboard/+bug/1677079) by setting the architecture within `snapcraft.yaml` to arm64 instead of armhf.