### PR TITLE
Fixing LP build when git am fails with not defined git user

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -26,8 +26,8 @@ parts:
         target-arch: arm
         build-packages: [device-tree-compiler, libfdt-dev, python, curl]
         prepare: |
-            git am --3way ../../../u-boot-generic*.patch
-            git am --3way ../../../u-boot-sd*.patch
+            git apply ../../../u-boot-generic*.patch
+            git apply ../../../u-boot-sd*.patch
             git clone git://codeaurora.org/quic/kernel/skales
         install: |
             skales/dtbTool -o u-boot-dt.img -s 2048 arch/arm/dts/
@@ -54,8 +54,8 @@ parts:
         target-arch: arm
         build-packages: [device-tree-compiler, libfdt-dev, python, curl]
         prepare: |
-            git am --3way ../../../u-boot-generic*.patch
-            git am --3way ../../../u-boot-emmc*.patch
+            git apply ../../../u-boot-generic*.patch
+            git apply ../../../u-boot-emmc*.patch
             git clone git://codeaurora.org/quic/kernel/skales
         install: |
             skales/dtbTool -o u-boot-dt.img -s 2048 arch/arm/dts/


### PR DESCRIPTION
This is addressing bug during building in Launchpad
When git am is  used on new machine, it fails because git is not setup with user, which can be used for commit. Using git apply does address this problem.

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>